### PR TITLE
Fix broken cover image filepath

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,4 +15,4 @@ The repository for code samples accompanying the book is located at https://gith
 
 The screencasts mentioned in the book are located at http://www.youtube.com/trainingatfarata.
 
-image::images/enterprisewebbook_cover_2013.png[]
+image::images/cover.png[]


### PR DESCRIPTION
II took a guess at the filename to use for the cover. 

If the image is too large it could be scaled in asciidoc. Let me know if you want me to amend the PR with that.
